### PR TITLE
Feature/added delay

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,58 @@
+name: Test, create and publish a Docker image
+
+on: [push]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
+      - name: Build jar 
+        run: mvn compile && mvn package
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: install xmllint
+        run: sudo apt  install libxml2-utils
+
+      - name: Extract branch postfix if not main branch
+        if: (github.ref != 'refs/heads/main') && (github.ref != 'refs/heads/master') 
+        run: |
+          echo "IMAGE_DEV_POSTFIX=-dev" >> $GITHUB_ENV
+      
+      - name: Extract version from pom file
+        id: project_version
+        run: |
+          version=$(sed -e 's/xmlns="[^\"]*"//g' pom.xml | xmllint --xpath "project/version/text()" - | tr '[:upper:]' '[:lower:]' )
+          echo "PROJECT_VERSION=$version" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,enable=true,value=${{ env.PROJECT_VERSION }}${{ env.IMAGE_DEV_POSTFIX }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# https://strimzi.io/docs/operators/0.26.0/deploying.html#creating-new-image-from-base-str
+FROM quay.io/strimzi/kafka:0.26.0-kafka-3.0.0
+USER root:root
+COPY ./target/*.jar /opt/kafka/plugins/
+USER 1001

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ callback.request.methods| Method of the callback url| POST, PUT,DELETE | | Y|
 callback.request.headers| Headers to be passed to the callback|JSON String ( Sample: `"{\"Content-Type\":\"application/json\",\"apikey\":\"API_KEY_HERE\"}"` )| |N
 exception.strategy| Strategy to be used in-case the callback request returns response with `retry` flag `true`.| PROGRESS_BACK_OFF_DROP_MESSAGE, PROGRESS_BACK_OFF_STOP_TASK, DROP_MESSAGE, STOP_TASK | PROGRESS_BACK_OFF_DROP_MESSAGE | Y
 retry.backoff.sec| The time in seconds to wait following an error before a retry attempt is made.| Integer | 5,30,60,300,600 | Y
+request.delay.sec| The time in seconds to wait before calling the http endpoint. Based on the record timestamp. If record has no timestamp the full delay is used from when the connector reads the record| Integer | 0 | N
 
 ### Exception strategies
 

--- a/src/main/java/nz/ac/auckland/kafka/http/sink/HttpSinkConnectorConfig.java
+++ b/src/main/java/nz/ac/auckland/kafka/http/sink/HttpSinkConnectorConfig.java
@@ -65,6 +65,12 @@ public class HttpSinkConnectorConfig extends AbstractConfig {
           "The time in seconds to wait following an error before a retry attempt is made for a errored request.";
   private static final String REQUEST_RETRY_BACKOFF_SEC_DISPLAY = "Request Retry Backoff (secs)";
 
+  public static final String DELAY_REQUEST_SEC = "request.delay.sec";
+  private static final String DELAY_REQUEST_SEC_DEFAULT = "0";
+  private static final String DELAY_REQUEST_SEC_DOC =
+      "The time in seconds to wait before issuing a request based on the kafka event timestamp";
+  private static final String DELAY_REQUEST_SEC_DISPLAY = "Request delay (secs)";
+
   private static final String API_REQUEST = "Request";
   private static final String RETRIES_GROUP = "Retries";
 
@@ -79,6 +85,7 @@ public class HttpSinkConnectorConfig extends AbstractConfig {
   public final String[] responseRetryBackoffsec;
   public final String[] requestRetryBackoffsec;
   public final ResponseExceptionStrategyHandlerFactory.ExceptionStrategy exceptionStrategy;
+  public final int requestDelay;
 
   public HttpSinkConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
     super(config, parsedConfig, false);
@@ -88,6 +95,7 @@ public class HttpSinkConnectorConfig extends AbstractConfig {
     readTimeout = getInt(READ_TIMEOUT);
     headers = getString(HEADERS);
     headerSeparator = getString(HEADER_SEPERATOR);
+    requestDelay = getInt(DELAY_REQUEST_SEC);
     responseRetryBackoffsec = getString(RESPONSE_RETRY_BACKOFF_SEC).split(RETRY_BACKOFF_SEC_SEPARATOR);
     requestRetryBackoffsec = getString(REQUEST_RETRY_BACKOFF_SEC).split(RETRY_BACKOFF_SEC_SEPARATOR);
     exceptionStrategy = ResponseExceptionStrategyHandlerFactory.ExceptionStrategy.valueOf(getString(EXCEPTION_STRATEGY).toUpperCase());
@@ -192,6 +200,16 @@ public class HttpSinkConnectorConfig extends AbstractConfig {
                 2,
                 ConfigDef.Width.SHORT,
                 EXCEPTION_STRATEGY_DISPLAY
+            ).define(
+                DELAY_REQUEST_SEC,
+                ConfigDef.Type.INT,
+                DELAY_REQUEST_SEC_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                DELAY_REQUEST_SEC_DOC,
+                RETRIES_GROUP,
+                2,
+                ConfigDef.Width.SHORT,
+                DELAY_REQUEST_SEC_DISPLAY
             );
   }
 }


### PR DESCRIPTION
The connector can now be configured to forward Kafka records with a delay. The delay depends on the timestamp of the record and the current time. If the record has no timestamp, the connector will wait for the full delay before forwarding the record. 

I have added a workflow that releases a docker image based on the version in the pom.xml file. The image is released on every push to the repository. If the branch is not master or main the image is released with a "-dev" postfix, for development and testing. 